### PR TITLE
Create custom ExternalDeploymentTaskSensor

### DIFF
--- a/dags/xdeployment_externaltasksensor.py
+++ b/dags/xdeployment_externaltasksensor.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from astronomer.providers.http.sensors.http import HttpSensorAsync
+from include.external_deployment.xd_external_task_sensor import ExternalDeploymentTaskSensorWrapper
+
+with DAG(
+    dag_id='xdeployment_externaltasksensor',
+    start_date=datetime(2022, 7, 27),
+    schedule_interval="0 13-22 * * 1-5",
+    template_searchpath="/usr/local/airflow/include/xdeployment_externaltasksensor/",
+    tags=["REST API", "Astronomer", "Deferrable Operator"],
+    description=f"""
+        Checks a seperate astronomer deployment to see if a task has completed
+    """,
+    catchup=False
+) as dag:
+
+    start, finish = [EmptyOperator(task_id=tid) for tid in ['start', 'finish']]
+
+    t = ExternalDeploymentTaskSensorWrapper(
+        external_dag_id="_04__shared",
+        external_task_id="finish"
+    )
+
+    start >> t >> finish
+

--- a/include/external_deployment/http.py
+++ b/include/external_deployment/http.py
@@ -1,0 +1,92 @@
+import asyncio
+from typing import Any, AsyncIterator, cast, Dict, Optional, Tuple, Union
+
+from airflow.exceptions import AirflowException
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils.state import State
+
+from astronomer.providers.http.hooks.http import HttpHookAsync
+
+
+class CustomHttpTrigger(BaseTrigger):
+    """
+    A trigger that fires when the request to a URL returns a non-404 status code
+
+    :param endpoint: The relative part of the full url
+    :type endpoint: str
+    :param http_conn_id: The HTTP Connection ID to run the sensor against
+    :type http_conn_id: str
+    :param method: The HTTP request method to use
+    :type method: str
+    :param data: payload to be uploaded or aiohttp parameters
+    :type data: dict
+    :param headers: The HTTP headers to be added to the GET request
+    :type headers: a dictionary of string key/value pairs
+    :param extra_options: Additional kwargs to pass when creating a request.
+        For example, ``run(json=obj)`` is passed as ``aiohttp.ClientSession().get(json=obj)``
+    :type extra_options: dict
+    :param poll_interval: Time to sleep using asyncio
+    :type poll_interval: float
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        http_conn_id: str = "http_default",
+        method: str = "GET",
+        data: Optional[Union[Dict[str, Any], str]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+        extra_options: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 5.0,
+    ):
+        super().__init__()
+        self.endpoint = endpoint
+        self.method = method
+        self.data = data
+        self.headers = headers
+        self.extra_options = extra_options or {}
+        self.http_conn_id = http_conn_id
+        self.poll_interval = poll_interval
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes HttpTrigger arguments and classpath."""
+        return (
+            # TODO: Use self.__class__ to retrieve the next line
+            # self.__class__.name,
+            "include.external_deployment.http.CustomHttpTrigger",
+            {
+                "endpoint": self.endpoint,
+                "data": self.data,
+                "headers": self.headers,
+                "extra_options": self.extra_options,
+                "http_conn_id": self.http_conn_id,
+                "poll_interval": self.poll_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """
+        """
+        hook = self._get_async_hook()
+        while True:
+            try:
+                response = await hook.run(
+                    endpoint=self.endpoint,
+                    data=self.data,
+                    headers=self.headers,
+                    extra_options=self.extra_options,
+                )
+                _response = cast(Dict[str, Any], await response.json())
+                if _response["state"] in State.finished:
+                    yield TriggerEvent(_response)
+                else:
+                    await asyncio.sleep(self.poll_interval)
+            except AirflowException as exc:
+                if str(exc).startswith("404"):
+                    await asyncio.sleep(self.poll_interval)
+
+    def _get_async_hook(self) -> HttpHookAsync:
+        return HttpHookAsync(
+            method=self.method,
+            http_conn_id=self.http_conn_id,
+        )

--- a/include/external_deployment/xd_external_task_sensor.py
+++ b/include/external_deployment/xd_external_task_sensor.py
@@ -1,0 +1,85 @@
+import json
+import requests
+
+from airflow.hooks.base import BaseHook
+from airflow.models import BaseOperator
+from airflow.models.variable import Variable
+from airflow.utils.context import Context
+from astronomer.providers.http.sensors.http import HttpSensorAsync
+from airflow.utils.context import Context
+
+from typing import Any, Dict, Iterable, Optional
+
+from include.external_deployment.http import CustomHttpTrigger
+
+def ExternalDeploymentTaskSensorWrapper(external_dag_id, external_task_id, http_conn_id='astronomer_default'):
+    '''
+    Upstream DAG in separate deployment needs to have the SAME schedule as the dag this task runs in or it wont work.
+    Astronomer Default connection should be set up like:
+    - Host: https://companyname.astronomer.run/<some-str>
+    - Extra: {"key_id": "<your-key-id>", "key_secret": "your-key-secret"}
+    '''
+    return ExternalDeploymentTaskSensor(
+        task_id=f"wait_for_{external_dag_id}",
+        method="GET",
+        endpoint=f"/api/v1/dags/{external_dag_id}/dagRuns/{{{{ run_id }}}}/taskInstances/{external_task_id}",
+        headers={
+          "cache-control": "no-cache",
+          "content-type": "application/json",
+          "accept": "application/json"
+        },
+        http_conn_id=http_conn_id
+    )
+
+class ExternalDeploymentTaskSensor(HttpSensorAsync):
+    '''
+    If the DAGs are on the same schedule, then this will return a deferrable operator checking if upstream task in an
+    upstream deployment has returned a success state
+    '''
+
+    def __init__(
+        self,
+        **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+
+    def _get_conn(self):
+        conn = BaseHook.get_connection(conn_id=self.http_conn_id)
+        extras = conn.extra_dejson
+        headers = {
+            "content-type": "application/json"
+        }
+        data = json.dumps({
+            "client_id": extras["key_id"],
+            "client_secret": extras["key_secret"],
+            "audience": "astronomer-ee",
+            "grant_type": "client_credentials"
+        })
+        #TODO: token is masked in the triggerer logs
+        r = requests.post(url=f"https://auth.astronomer.io/oauth/token", data=data, headers=headers).json()
+        return {"host": conn.host, "token": r["access_token"]}
+
+    def execute(self, context: Context) -> None:
+        conn = self._get_conn()
+        authorized_headers = self.headers
+        authorized_headers['authorization'] = f"Bearer {conn['token']}"
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=CustomHttpTrigger(
+                method=self.hook.method,
+                endpoint=self.endpoint,
+                data=self.request_params,
+                headers=authorized_headers,
+                http_conn_id=self.http_conn_id,
+                extra_options=self.extra_options,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Dict[str, Any], event: Optional[Dict[Any, Any]] = None) -> None:
+        if event:
+            self.log.info("Task succeeded. Response: %s", event)
+            return True
+        else:
+            self.log.info("Task did not succeed. Response: %s", event)
+        raise ValueError(f"Response: {event}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ apache-airflow-providers-databricks==2.7.0
 apache-airflow-providers-google==7.0.0
 apache-airflow-providers-http==3.0.0
 apache-airflow-providers-slack==4.2.3
-astronomer-providers[databricks]
+astronomer-providers[all]
 holidays


### PR DESCRIPTION
The ExternalDeploymentTaskSensor wraps the HttpSensorAsync to create a deferrable operator that checks an external upstream airflow deployment for a task's successful completion given a dag_id and task_id. A big assumption that is made is that the DAG where this component runs needs to be on the same schedule as the DAG that is in the external upstream deployment.